### PR TITLE
Update instructions with latest checkout actions version

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ jobs:
     - uses: adwerx/pronto-ruby@v2.4
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 ```
 
 With specific runners:
@@ -78,6 +77,18 @@ name: Pronto
       with:
         runners: >-
           rubocop rails_schema yamllint
+```
+
+If you want to use `actions/checkout@v2`:
+
+```yaml
+name: Pronto
+# ...
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - run: |
+        git fetch --no-tags --prune origin
 ```
 
 ### Development / Contributions


### PR DESCRIPTION
Hi!

First of all - huge thanks for you awesome library, it looks great.

I am currently transferring my existing CircleCI config to Github Actions, and during the transition of pronto I found out that on `actions/checkout@v1` got some very surprising bug with update git submodules under my project. We use git submodules to keep rubocop and other configurations the same across all projects in our company.

So digging a bit around I managed to make current actions to be compatible with `actions/checkout@v2`. So thought you would love to try it yourself and keep instructions for latest version under README. 